### PR TITLE
Add Krator OS builder scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# KratorOS
+# Krator OS
+
+Krator OS is a modular, high-performance Debian-based distribution designed for security professionals, entrepreneurs, and AI developers. This repository contains build scripts and configuration files to generate the ISO, Raspberry Pi image, and container builds.
+
+## Directory Structure
+
+- `krator-os/` - main build environment
+  - `build/` - scripts and templates to produce images
+  - `ai/` - Krator assistant daemon and configs
+  - `config/` - desktop and security settings
+  - `scripts/` - helper scripts and setup wizards
+  - `installer/` - preseed and post-install tools
+  - `docs/` - user and developer documentation
+
+Run `make -C krator-os iso` to build a live ISO or `make docker` for the Docker image.
+

--- a/krator-os/Makefile
+++ b/krator-os/Makefile
@@ -1,0 +1,21 @@
+.PHONY: iso pi docker lxc clean
+
+ISO_NAME=krator-os.iso
+PI_IMAGE=krator-pi.img
+
+iso:
+	cd build && bash live-build.sh
+	mv build/*.iso $(ISO_NAME) || true
+
+pi:
+	cd build && sudo bash pi-image.sh
+
+docker:
+	docker build -t krator-os -f build/Dockerfile .
+
+lxc:
+	@echo "Use build/lxc-config with lxc-create"
+
+clean:
+	rm -rf build/lb-config build/pi-rootfs $(ISO_NAME) $(PI_IMAGE)
+

--- a/krator-os/ai/krator.conf
+++ b/krator-os/ai/krator.conf
@@ -1,0 +1,4 @@
+# Krator AI daemon configuration
+[general]
+model = "gpt4all"
+log_path = "/var/log/krator/krator.log"

--- a/krator-os/ai/krator_daemon.py
+++ b/krator-os/ai/krator_daemon.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Krator AI daemon placeholder"""
+import time
+
+CONFIG_PATH = '/etc/krator/krator.conf'
+
+
+def load_config(path):
+    # TODO: load configuration
+    return {}
+
+
+def main():
+    config = load_config(CONFIG_PATH)
+    while True:
+        # TODO: integrate AI models and voice triggers
+        time.sleep(5)
+
+
+if __name__ == '__main__':
+    main()

--- a/krator-os/build/Dockerfile
+++ b/krator-os/build/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:bookworm
+
+# Basic packages
+RUN apt-get update && apt-get install -y \
+    sudo curl git systemd && rm -rf /var/lib/apt/lists/*
+
+# Add Krator base setup
+COPY ../scripts/bootstrap.sh /bootstrap.sh
+RUN bash /bootstrap.sh && rm /bootstrap.sh
+
+CMD ["/bin/bash"]
+

--- a/krator-os/build/live-build.sh
+++ b/krator-os/build/live-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Build Krator OS Live ISO using Debian live-build
+set -e
+LB_CONFIG=lb-config
+
+if [ ! -d "$LB_CONFIG" ]; then
+    mkdir "$LB_CONFIG"
+    lb config -d bookworm --binary-images iso-hybrid --debian-installer live --archive-areas 'main contrib non-free' --bootappend-live "boot=live components" -o "$LB_CONFIG"
+fi
+
+lb build -b iso-hybrid --config "$LB_CONFIG"
+

--- a/krator-os/build/lxc-config
+++ b/krator-os/build/lxc-config
@@ -1,0 +1,8 @@
+lxc.include = /usr/share/lxc/config/debian.common.conf
+lxc.arch = linux64
+lxc.rootfs.path = dir:/var/lib/lxc/krator/rootfs
+lxc.uts.name = krator
+
+lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
+lxc.pty.max = 1024
+

--- a/krator-os/build/pi-image.sh
+++ b/krator-os/build/pi-image.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Build Raspberry Pi image using debootstrap
+set -e
+TARGET=pi-rootfs
+DEBIAN_RELEASE=bookworm
+
+mkdir -p $TARGET
+sudo debootstrap --arch arm64 $DEBIAN_RELEASE $TARGET http://deb.debian.org/debian
+
+# Add Raspberry Pi firmware and bootloader steps here
+# Create image file and copy rootfs
+

--- a/krator-os/config/desktop/xfce.conf
+++ b/krator-os/config/desktop/xfce.conf
@@ -1,0 +1,1 @@
+# XFCE desktop settings placeholder

--- a/krator-os/config/desktop_entries/krator.desktop
+++ b/krator-os/config/desktop_entries/krator.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Krator Assistant
+Exec=/usr/bin/krator-daemon
+Type=Application
+Comment=AI assistant

--- a/krator-os/config/security/apparmor.profile
+++ b/krator-os/config/security/apparmor.profile
@@ -1,0 +1,1 @@
+# AppArmor profile placeholder for Krator OS

--- a/krator-os/docs/README.md
+++ b/krator-os/docs/README.md
@@ -1,0 +1,3 @@
+# Krator OS
+
+Krator OS is a security-focused, AI-enabled Debian distribution. This repository contains build scripts and configuration files used to generate the various deployment images.

--- a/krator-os/docs/architecture.md
+++ b/krator-os/docs/architecture.md
@@ -1,0 +1,9 @@
+# Krator OS Architecture
+
+This document outlines the high-level components of Krator OS.
+
+- **Build scripts** located in `build/` produce ISO, Raspberry Pi images, and container images.
+- **AI components** in `ai/` provide the Krator assistant daemon and configuration.
+- **System configuration** under `config/` includes desktop environment and security profiles.
+- **Installation** tools in `installer/` leverage preseed and post-install scripts.
+- **Automation scripts** in `scripts/` bootstrap systems and provide an initial setup wizard.

--- a/krator-os/installer/post-install.sh
+++ b/krator-os/installer/post-install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+# Post-install steps placeholder

--- a/krator-os/installer/preseed.cfg
+++ b/krator-os/installer/preseed.cfg
@@ -1,0 +1,1 @@
+# Preseed configuration placeholder

--- a/krator-os/scripts/bootstrap.sh
+++ b/krator-os/scripts/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Bootstrap base system for Krator OS
+
+apt-get update
+apt-get install -y sudo curl git
+# TODO: install additional packages and apply configs

--- a/krator-os/scripts/install.sh
+++ b/krator-os/scripts/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Installer entry script placeholder
+
+echo "Krator OS installer starting..."
+# TODO: add installer logic

--- a/krator-os/scripts/krator-setup.py
+++ b/krator-os/scripts/krator-setup.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+"""Initial setup wizard placeholder"""
+
+print("Welcome to Krator OS setup wizard")
+# TODO: implement interactive setup steps


### PR DESCRIPTION
## Summary
- scaffold `krator-os` directory with build scripts and configs
- add placeholder AI daemon, installer scripts, and documentation
- create Makefile to build ISO, Pi image and container
- update root README with instructions

## Testing
- `make -C krator-os iso --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_684f11d22cec8328abdd5aa087c78741