### PR TITLE
Add run.sh helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ make -C krator-os docker    # build Docker image
 
 The `krator-os` directory contains the build scripts, configuration and
 assistant source code.
+
+To start the Krator AI daemon directly, run:
+
+```
+./run.sh
+```
+
+The script activates an existing Python virtual environment if available and then launches the daemon.
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Run the Krator AI daemon
+set -e
+
+# Activate virtual environment if present
+if [ -f "venv/bin/activate" ]; then
+    . "venv/bin/activate"
+elif [ -f ".venv/bin/activate" ]; then
+    . ".venv/bin/activate"
+fi
+
+exec python3 krator-os/ai/krator_daemon.py "$@"


### PR DESCRIPTION
## Summary
- add `run.sh` to launch the Krator AI daemon
- document the helper script in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f1e93e4648328b1c16e76aad42403