### PR TITLE
Add configurable model command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ make -C krator-os docker    # build Docker image
 
 The `krator-os` directory contains the build scripts, configuration and
 assistant source code.
+
+To run a local language model set the `model_cmd` option in
+`krator-os/ai/krator.conf` to the command or path of your model binary:
+
+```
+[general]
+model = "gpt4all"
+model_cmd = "/usr/local/bin/llama"
+```
+
+The daemon will use this command when running `run_local_model`.

--- a/krator-os/ai/krator.conf
+++ b/krator-os/ai/krator.conf
@@ -1,4 +1,5 @@
 # Krator AI daemon configuration
 [general]
 model = "gpt4all"
+model_cmd = "/usr/local/bin/llama"
 log_path = "/var/log/krator/krator.log"

--- a/krator-os/ai/krator_daemon.py
+++ b/krator-os/ai/krator_daemon.py
@@ -21,7 +21,11 @@ def load_config(path: Path) -> configparser.ConfigParser:
     if path.exists():
         cfg.read(path)
     else:
-        cfg['general'] = {'model': 'gpt4all', 'openai_key': ''}
+        cfg['general'] = {
+            'model': 'gpt4all',
+            'openai_key': '',
+            'model_cmd': 'llama.cpp'
+        }
     return cfg
 
 
@@ -67,6 +71,7 @@ def main():
     cfg = load_config(CONFIG_PATH)
     model = cfg['general'].get('model', 'gpt4all')
     api_key = cfg['general'].get('openai_key', '')
+    model_cmd = cfg['general'].get('model_cmd', 'llama.cpp')
 
     print('Krator AI daemon started. Type a prompt and press enter.')
     for line in sys.stdin:
@@ -83,7 +88,7 @@ def main():
         if model == 'openai' and api_key:
             response = run_openai(prompt, api_key)
         else:
-            response = run_local_model(prompt)
+            response = run_local_model(prompt, model_cmd)
         print(response)
         sys.stdout.flush()
         time.sleep(0.1)


### PR DESCRIPTION
## Summary
- add `model_cmd` option to AI configuration
- read new setting in `krator_daemon.py` and pass to `run_local_model`
- document `model_cmd` in README

## Testing
- `python3 -m py_compile krator-os/ai/krator_daemon.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1e77de9483289db031c235667983