### PR TITLE
Add pytest tests and workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Python Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r krator-os/requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+import subprocess
+
+AI_PATH = Path(__file__).resolve().parents[1] / 'krator-os' / 'ai'
+if str(AI_PATH) not in sys.path:
+    sys.path.insert(0, str(AI_PATH))
+
+from krator_daemon import load_config, run_local_model
+
+
+def test_load_config_default(tmp_path):
+    cfg = load_config(tmp_path / 'missing.conf')
+    assert cfg['general']['model'] == 'gpt4all'
+    assert cfg['general']['openai_key'] == ''
+
+
+def test_load_config_existing(tmp_path):
+    path = tmp_path / 'krator.conf'
+    path.write_text('[general]\nmodel=openai\nopenai_key=abc\n')
+    cfg = load_config(path)
+    assert cfg['general']['model'] == 'openai'
+    assert cfg['general']['openai_key'] == 'abc'
+
+
+def test_run_local_model_success(monkeypatch):
+    def fake_run(args, capture_output, text, check):
+        class Res:
+            stdout = 'ok'
+        fake_run.called = args
+        return Res()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    output = run_local_model('prompt', model_cmd='cmd')
+    assert fake_run.called == ['cmd', '--prompt', 'prompt']
+    assert output == 'ok'
+
+
+def test_run_local_model_error(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=kwargs.get('args', args[0]))
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    output = run_local_model('prompt', model_cmd='cmd')
+    assert output.startswith('[error running local model:')


### PR DESCRIPTION
## Summary
- add unit tests for krator daemon helpers
- run tests in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1e98974c8328b47c2461cd3d1cae