### PR TITLE
Use hashed password for installer

### DIFF
--- a/krator-os/docs/security.md
+++ b/krator-os/docs/security.md
@@ -7,3 +7,15 @@ protection and ensures auditd is running for system auditing.
 Additional profiles can be placed under `config/security/` to extend AppArmor
 or other hardening mechanisms.
 
+## Generating Password Hashes
+
+The installer preseed expects a hashed user password. You can generate a
+SHA-512 hash using `mkpasswd` from the `whois` package:
+
+```bash
+mkpasswd --method=SHA-512
+```
+
+Enter your desired password when prompted and copy the resulting hash to the
+`passwd/user-password-crypted` field in `installer/preseed.cfg`.
+

--- a/krator-os/installer/preseed.cfg
+++ b/krator-os/installer/preseed.cfg
@@ -10,8 +10,8 @@ netcfg/get_hostname=krator
 # User
 passwd/user-fullname=Krator User
 passwd/username=krator
-passwd/user-password=password
-passwd/user-password-again=password
+# The hashed password below is for the string "password"
+passwd/user-password-crypted=$6$rSZenTu4YLcyj8fQ$SZzSnGJwbc4bl3MfkgXUxqq2Vh.s4FJYjg3CSWtuX5gRciuSwpW4tIFWCgDe1OVOcgjoShoOC2zU9b/B0amrY0
 
 # Partitioning (use entire disk with LVM)
 d-i partman-auto/method string lvm


### PR DESCRIPTION
## Summary
- use `passwd/user-password-crypted` in the installer preseed file
- document how to generate a password hash with `mkpasswd`

## Testing
- `pip3 install -r krator-os/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684f1e7ec38883288a54e9162a3a3436