### PR TITLE
Install AI daemon in bootstrap

### DIFF
--- a/krator-os/scripts/bootstrap.sh
+++ b/krator-os/scripts/bootstrap.sh
@@ -5,8 +5,20 @@ set -e
 apt-get update
 apt-get install -y sudo curl git ufw fail2ban auditd \
     xfce4 xfce4-goodies openssh-server python3-pip
-
 bash "$(dirname "$0")/hardening.sh"
 
-# Placeholder for additional setup (AI assistant, configs)
+
+# Install Python dependencies for the Krator daemon
+pip3 install --break-system-packages -r "$(dirname "$0")/../requirements.txt"
+
+# Deploy the Krator AI daemon and configuration
+install -Dm755 "$(dirname "$0")/../ai/krator_daemon.py" /usr/local/bin/krator_daemon.py
+install -Dm644 "$(dirname "$0")/../ai/krator.conf" /etc/krator/krator.conf
+
+# Install and enable the optional systemd service
+if [ -d /etc/systemd/system ]; then
+    install -Dm644 "$(dirname "$0")/../config/systemd/krator.service" \
+        /etc/systemd/system/krator.service
+    systemctl enable krator.service
+fi
 


### PR DESCRIPTION
## Summary
- install python dependencies and Krator daemon in bootstrap script
- include krator daemon config and systemd service
- enable the daemon automatically

## Testing
- `find krator-os -name '*.py' -print0 | xargs -0 python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_684f1e84317c8328a93a1fea4adbb14e