### PR TITLE
Improve default config handling

### DIFF
--- a/krator-os/ai/krator_daemon.py
+++ b/krator-os/ai/krator_daemon.py
@@ -18,10 +18,9 @@ PLUGIN_DIR = Path(__file__).parent / 'plugins'
 
 def load_config(path: Path) -> configparser.ConfigParser:
     cfg = configparser.ConfigParser()
+    cfg['general'] = {'model': 'gpt4all', 'openai_key': ''}
     if path.exists():
         cfg.read(path)
-    else:
-        cfg['general'] = {'model': 'gpt4all', 'openai_key': ''}
     return cfg
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -23,6 +23,14 @@ def test_load_config_existing(tmp_path):
     assert cfg['general']['openai_key'] == 'abc'
 
 
+def test_load_config_missing_section(tmp_path):
+    path = tmp_path / 'krator.conf'
+    path.write_text('[other]\nkey=value\n')
+    cfg = load_config(path)
+    assert cfg['general']['model'] == 'gpt4all'
+    assert cfg['general']['openai_key'] == ''
+
+
 def test_run_local_model_success(monkeypatch):
     def fake_run(args, capture_output, text, check):
         class Res:


### PR DESCRIPTION
## Summary
- update config loading to initialize defaults then override if file exists
- add regression test for config files without a `[general]` section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f208f49f083288e3381633498831b