### PR TITLE
Add plugin support improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ pip3 install -r requirements.txt
 The `krator-os` directory contains the build scripts, configuration and
 assistant source code.
 
-To start the Krator AI daemon directly, run:
+To start the Krator AI daemon directly, run either `run.sh` or the
+`krator-daemon` wrapper script:
 
 ```
-./run.sh
+./krator-daemon
 ```
 
 The script activates an existing Python virtual environment if available and then launches the daemon.
+
+Plugins can be invoked by prefixing a command with `!` when interacting with
+the daemon. See `krator-os/ai/plugins/README.md` for available plugins.
 

--- a/krator-daemon
+++ b/krator-daemon
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Wrapper script to start the Krator AI daemon
+set -e
+DIR="$(dirname "$0")"
+
+if [ -f "$DIR/venv/bin/activate" ]; then
+    . "$DIR/venv/bin/activate"
+elif [ -f "$DIR/.venv/bin/activate" ]; then
+    . "$DIR/.venv/bin/activate"
+fi
+
+exec python3 "$DIR/krator-os/ai/krator_daemon.py" "$@"

--- a/krator-os/ai/plugins/README.md
+++ b/krator-os/ai/plugins/README.md
@@ -1,1 +1,9 @@
 # Krator AI plugins
+
+Plugins extend the assistant with custom commands. Available plugins:
+
+- `example_plugin` – echoes any text passed to it.
+- `data_sweep_plugin` – runs the `data_sweep.sh` script to gather system info.
+
+Invoke a plugin by prefixing its name with `!` when interacting with the daemon.
+

--- a/krator-os/ai/plugins/data_sweep_plugin.py
+++ b/krator-os/ai/plugins/data_sweep_plugin.py
@@ -1,0 +1,18 @@
+"""Run the data_sweep.sh script and return its output."""
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / 'scripts' / 'data_sweep.sh'
+
+
+def run(args: str) -> str:
+    cmd = [str(SCRIPT)]
+    if args:
+        cmd.extend(args.split())
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except Exception as exc:
+        return f"[data sweep error: {exc}]"
+

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -6,7 +6,7 @@ AI_PATH = Path(__file__).resolve().parents[1] / 'krator-os' / 'ai'
 if str(AI_PATH) not in sys.path:
     sys.path.insert(0, str(AI_PATH))
 
-from krator_daemon import load_config, run_local_model
+from krator_daemon import load_config, run_local_model, run_plugin
 
 
 def test_load_config_default(tmp_path):
@@ -51,3 +51,12 @@ def test_run_local_model_error(monkeypatch):
     monkeypatch.setattr(subprocess, 'run', fake_run)
     output = run_local_model('prompt', model_cmd='cmd')
     assert output.startswith('[error running local model:')
+
+
+def test_run_plugin_example():
+    output = run_plugin('example', 'hi')
+    assert output == 'Plugin executed: hi'
+
+
+def test_run_plugin_missing():
+    assert run_plugin('nosuchplugin', '') == ''


### PR DESCRIPTION
## Summary
- add a wrapper script `krator-daemon`
- document how to run the daemon and use plugins
- add a `data_sweep_plugin` example
- expand plugins README
- test plugin support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2317ea0c8328b9430895671043b2